### PR TITLE
changed guideline to follow let/const standard

### DIFF
--- a/Documentation/Guidelines/styleguide.md
+++ b/Documentation/Guidelines/styleguide.md
@@ -231,7 +231,7 @@ let currentAcceleration = 2.35; //reassignable
 const gravity = 9.82; //not reassignable
 ```
 
-Use uppercase with each word separated by an underscore when naming constants, like this: ``SOME_CONSTANT``.
+Use uppercase with each word separated by an underscore when naming **global** (outside any function scope) constants, like this: ``SOME_CONSTANT``.
 
 #### Delete
 


### PR DESCRIPTION
In my eyes it seems like this is the way forward when declaring variables, make sure to **follow** it. 
Hint, hint @Keffin.